### PR TITLE
chore: dummy PR to trigger GitHub Actions indexing

### DIFF
--- a/.github/workflows/.trigger-1746195510546.md
+++ b/.github/workflows/.trigger-1746195510546.md
@@ -1,0 +1,1 @@
+# Dummy PR to force indexing


### PR DESCRIPTION
Cette PR existe uniquement pour forcer l’indexation des fichiers .yaml comme workflows.